### PR TITLE
Three fingers to go to home or end

### DIFF
--- a/Tweak.mm
+++ b/Tweak.mm
@@ -123,6 +123,7 @@
     static BOOL longPress = NO;
     static BOOL handWriting = NO;
     static BOOL haveCheckedHand = NO;
+    static BOOL goHomeEnd = NO;
 
     int touchesCount = [gesture numberOfTouches];
     if (touchesCount > numberOfTouches) {
@@ -187,6 +188,7 @@
         gesture.cancelsTouchesInView = NO;
         handWriting = NO;
         haveCheckedHand = NO;
+        goHomeEnd = NO;
     }
     else if (longPress || handWriting) {
         return;
@@ -237,8 +239,10 @@
         hasStarted = YES;
 
         int scale = 16;
-        if (numberOfTouches >= 2) {
+        if (numberOfTouches == 2) {
             scale = 8; // make it go faster
+        } else if (numberOfTouches == 3) {
+            goHomeEnd = YES;
         }
 
         // Get caracters back it should go
@@ -255,7 +259,10 @@
             }
         }
 
-        if (shiftHeldDown) {
+        if (goHomeEnd) {
+        	newLocaation = offset.x > 0 ? 0 : textLength;
+        	newLength = 0;
+        } else if (shiftHeldDown) {
             if (pointsChanged > 0) {
                 newLength += pointsChanged;
                 

--- a/Tweak.mm
+++ b/Tweak.mm
@@ -260,7 +260,7 @@
         }
 
         if (goHomeEnd) {
-        	newLocaation = offset.x > 0 ? 0 : textLength;
+        	newLocation = offset.x > 0 ? 0 : textLength;
         	newLength = 0;
         } else if (shiftHeldDown) {
             if (pointsChanged > 0) {

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: com.iky1e.swipeselection
 Name: SwipeSelection
 Depends: mobilesubstrate
-Version: 1.0.2
+Version: 1.0.3
 Architecture: iphoneos-arm
 Description: Swipe along the keyboard to move the cursor and select text.
 Maintainer: Kyle Howells

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: com.iky1e.swipeselection
 Name: SwipeSelection
 Depends: mobilesubstrate
-Version: 1.0.1
+Version: 1.0.2
 Architecture: iphoneos-arm
 Description: Swipe along the keyboard to move the cursor and select text.
 Maintainer: Kyle Howells


### PR DESCRIPTION
I've added three fingers to skip the cursor to the start or end of the text. 
I can't compile using the on-device 3.0 SDK (due to other errors) so I'm not sure if this'll compile, but I'm pretty sure I got the logic right. 
