### PR TITLE
Better check for handwriting keyboards

### DIFF
--- a/Tweak.mm
+++ b/Tweak.mm
@@ -89,6 +89,7 @@
 -(BOOL)callLayoutIsShiftKeyBeingHeld;
 -(void)_KHKeyboardGestureDidPan:(UIPanGestureRecognizer*)gesture;
 -(void)handleDelete;
+-(BOOL)handwritingPlane;
 @end
 
 


### PR DESCRIPTION
Layout classes which support handwriting implement -handwritingPlane and return YES. This is a better way to check for handwriting layouts.

There are custom keyboard layouts currently which do not have any subview with "Handwriting" in its class name (e.g. Grafiti). Grafiti implements -handwritingPlane just like the stock iOS keyboards which support handwriting.
